### PR TITLE
Update permissions for repositories of score servers

### DIFF
--- a/team-admin.tf
+++ b/team-admin.tf
@@ -73,9 +73,3 @@ resource "github_team_membership" "admin-kyontan" {
   username = "${github_membership.kyontan.username}"
   role = "member"
 }
-
-resource "github_team_membership" "admin-suzutan" {
-  team_id = "${github_team.admin.id}"
-  username = "${github_membership.suzutan.username}"
-  role = "member"
-}

--- a/team-admin.tf
+++ b/team-admin.tf
@@ -48,9 +48,9 @@ resource "github_team_repository" "admin-ictsc-playbooks" {
     permission = "admin"
 }
 
-resource "github_team_repository" "admin-ictsc-score" {
+resource "github_team_repository" "admin-ictsc-score-server" {
     team_id = "${github_team.admin.id}"
-    repository = "ictsc-score"
+    repository = "ictsc-score-server"
     permission = "admin"
 }
 

--- a/team-ictsc8.tf
+++ b/team-ictsc8.tf
@@ -48,9 +48,9 @@ resource "github_team_repository" "ictsc8-ictsc-playbooks" {
     permission = "pull"
 }
 
-resource "github_team_repository" "ictsc8-ictsc-score" {
+resource "github_team_repository" "ictsc8-ictsc-score-server" {
     team_id = "${github_team.ictsc8.id}"
-    repository = "ictsc-score"
+    repository = "ictsc-score-server"
     permission = "pull"
 }
 

--- a/team-score-dev.tf
+++ b/team-score-dev.tf
@@ -6,27 +6,15 @@ resource "github_team" "score-dev" {
 }
 
 // Team repository resource
-resource "github_team_repository" "score-dev-ictsc-score" {
+resource "github_team_repository" "score-dev-ictsc-score-server" {
     team_id = "${github_team.score-dev.id}"
-    repository = "ictsc-score"
-    permission = "admin"
-}
-
-resource "github_team_repository" "score-dev-ictsc-score-ember" {
-    team_id = "${github_team.score-dev.id}"
-    repository = "ictsc-score-ember"
+    repository = "ictsc-score-server"
     permission = "admin"
 }
 
 // Team Members
-resource "github_team_membership" "score-dev-chibiegg" {
+resource "github_team_membership" "score-dev-kyontan" {
   team_id = "${github_team.score-dev.id}"
-  username = "${github_membership.chibiegg.username}"
-  role = "maintainer"
-}
-
-resource "github_team_membership" "score-dev-palloc" {
-  team_id = "${github_team.score-dev.id}"
-  username = "${github_membership.palloc.username}"
+  username = "${github_membership.kyontan.username}"
   role = "maintainer"
 }


### PR DESCRIPTION
Remove permissions for old 2 repositories:
- `ictsc/ictsc-score`
- `ictsc/ictsc-score-ember`

And add one:
- `ictsc/ictsc-score-server` (from `kyontan/ictsc-score-server`)

also, this edits members of GitHub team `score-dev`.