### PR TITLE
rewrite_authorized_keys.shの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-==========
+# ICTSC github members
+
+[![CircleCI](https://circleci.com/gh/ictsc/ictsc-github-member.svg?style=svg)](https://circleci.com/gh/ictsc/ictsc-github-member)
+
 Manage github membership by Terraform
 
-# How to append user
+## How to append user
 
-## Sample flow
+### Sample flow
 
 1. fork this repo.
 1. edit members.tf and team-ictsc6.tf like [this](https://github.com/ictsc/ictsc-github-member/pull/5).

--- a/rewrite_authorized_keys.sh
+++ b/rewrite_authorized_keys.sh
@@ -6,7 +6,7 @@
 #   bash rewrite_authorized_keys.sh [Github Team] [Output File]
 # 
 # Example:
-#   curl -sS https://raw.githubusercontent.com/h-otter/ictsc-github-member/master/rewrite_authorized_keys.sh | bash -s -- ictsc2019 ~/.ssh/authorized_keys
+#   curl -sS https://raw.githubusercontent.com/ictsc/ictsc-github-member/master/rewrite_authorized_keys.sh | bash -s -- ictsc2019 ~/.ssh/authorized_keys
 
 team=$1
 output=$2

--- a/rewrite_authorized_keys.sh
+++ b/rewrite_authorized_keys.sh
@@ -18,11 +18,11 @@ fi
 members=`curl -sS https://raw.githubusercontent.com/ictsc/ictsc-github-member/production/terraform.tfstate | grep github_team_membership.$team | sed -e 's/^.*ictsc[0-9]*-\(.*\)\".*$/\1/'`
 if [ -z "$members" ]
 then
-  echo "members are not found, maybe $team do not exists"
+  echo "members are not found, maybe $team does not exists"
   exit 1
 fi
 
-echo "# These keys are imported members of Github Team $team defined by github.com/ictsc/ictsc-github-member" > $output
+echo "# These public keys are imported from GitHub team $team at github.com/ictsc/ictsc-github-member" > $output
 for m in $members
 do
   curl -sS https://github.com/$m.keys | xargs -n1 -I{} echo {} $m@gh | tee --append $output

--- a/rewrite_authorized_keys.sh
+++ b/rewrite_authorized_keys.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -x
+
+# rewrite_authorized_keys.sh - Rewrite a authorized_keys file with imported public keys by a Github Team defined on github.com/ictsc/ictsc-github-member
+#
+# Usage:
+#   bash rewrite_authorized_keys.sh [Github Team] [Output File]
+# 
+# Example:
+#   bash rewrite_authorized_keys.sh ictsc2019 ~/.ssh/authorized_keys
+
+team=$1
+output=$2
+if [ -z $output ]
+then
+  output="/dev/null"
+fi
+
+members=`curl -sS https://raw.githubusercontent.com/ictsc/ictsc-github-member/production/terraform.tfstate | grep github_team_membership.$team | sed -e 's/^.*-\(.*\)\".*$/\1/'`
+if [ -z "$members" ]
+then
+  echo "members are not found, maybe $team do not exists"
+  exit 1
+fi
+
+echo "# imported by github.com/ictsc/ictsc-github-member" > $output
+for m in $members
+do
+  curl -sS https://github.com/$m.keys | grep -v "Not Found" | xargs -n1 -I{} echo {} $m@gh | tee --append $output
+done
+
+if [ $output != "/dev/null" ]
+then
+  chmod 600 $output
+fi

--- a/rewrite_authorized_keys.sh
+++ b/rewrite_authorized_keys.sh
@@ -6,7 +6,7 @@
 #   bash rewrite_authorized_keys.sh [Github Team] [Output File]
 # 
 # Example:
-#   bash rewrite_authorized_keys.sh ictsc2019 ~/.ssh/authorized_keys
+#   curl -sS https://raw.githubusercontent.com/h-otter/ictsc-github-member/master/rewrite_authorized_keys.sh | bash -s -- ictsc2019 ~/.ssh/authorized_keys
 
 team=$1
 output=$2
@@ -22,7 +22,7 @@ then
   exit 1
 fi
 
-echo "# imported by github.com/ictsc/ictsc-github-member" > $output
+echo "# These keys are imported members of Github Team $team defined by github.com/ictsc/ictsc-github-member" > $output
 for m in $members
 do
   curl -sS https://github.com/$m.keys | grep -v "Not Found" | xargs -n1 -I{} echo {} $m@gh | tee --append $output

--- a/rewrite_authorized_keys.sh
+++ b/rewrite_authorized_keys.sh
@@ -15,7 +15,7 @@ then
   output="/dev/null"
 fi
 
-members=`curl -sS https://raw.githubusercontent.com/ictsc/ictsc-github-member/production/terraform.tfstate | grep github_team_membership.$team | sed -e 's/^.*-\(.*\)\".*$/\1/'`
+members=`curl -sS https://raw.githubusercontent.com/ictsc/ictsc-github-member/production/terraform.tfstate | grep github_team_membership.$team | sed -e 's/^.*ictsc[0-9]*-\(.*\)\".*$/\1/'`
 if [ -z "$members" ]
 then
   echo "members are not found, maybe $team do not exists"
@@ -25,7 +25,7 @@ fi
 echo "# These keys are imported members of Github Team $team defined by github.com/ictsc/ictsc-github-member" > $output
 for m in $members
 do
-  curl -sS https://github.com/$m.keys | grep -v "Not Found" | xargs -n1 -I{} echo {} $m@gh | tee --append $output
+  curl -sS https://github.com/$m.keys | xargs -n1 -I{} echo {} $m@gh | tee --append $output
 done
 
 if [ $output != "/dev/null" ]


### PR DESCRIPTION
- 各サーバの公開鍵管理が面倒になってきたので、githubの公開鍵で一元管理しようと考え、これを作りました
- 動作確認済み
- マージされれば以下のようなコマンドを叩くだけで、鍵の更新が終了します

```sh
curl -sS https://raw.githubusercontent.com/ictsc/ictsc-github-member/master/rewrite_authorized_keys.sh | bash -s -- ictsc2019 ~/.ssh/authorized_keys
```