### PR TITLE
update admin role

### DIFF
--- a/team-admin.tf
+++ b/team-admin.tf
@@ -12,59 +12,59 @@ resource "github_team" "admin" {
 resource "github_team_membership" "admin-whywaita" {
   team_id  = github_team.admin.id
   username = github_membership.whywaita.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-tar-xzvff" {
   team_id  = github_team.admin.id
   username = github_membership.tar-xzvff.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-h-otter" {
   team_id  = github_team.admin.id
   username = github_membership.h-otter.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-sharknasuhorse" {
   team_id  = github_team.admin.id
   username = github_membership.sharknasuhorse.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-uplus" {
   team_id  = github_team.admin.id
   username = github_membership.uplus.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-yukamoja" {
   team_id  = github_team.admin.id
   username = github_membership.yukamoja.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-takemhaya" {
   team_id  = github_team.admin.id
   username = github_membership.takehaya.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-x86taka" {
   team_id  = github_team.admin.id
   username = github_membership.x86taka.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-proelbtn" {
   team_id  = github_team.admin.id
   username = github_membership.proelbtn.username
-  role     = "member"
+  role     = "maintainer"
 }
 
 resource "github_team_membership" "admin-onokatio" {
   team_id  = github_team.admin.id
   username = github_membership.onokatio.username
-  role     = "member"
+  role     = "maintainer"
 }


### PR DESCRIPTION
Adminチームのメンバーはorgのownerも兼任しているが、ownerはmember権限になれない（最低でもmaintainer権限）ため、role=memberと書いた定義が永遠にdiffを発生させている。
それを解消させるためのPR。