### PR TITLE
Update upload-artifact; v3 -> v4

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Backup tfstate to artifact
         if: github.ref == 'refs/heads/production' && github.event_name == 'push'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform.tfstate
           path: terraform.tfstate

--- a/team-admin.tf
+++ b/team-admin.tf
@@ -14,9 +14,10 @@ locals {
     "onokatio",
     "Explosive6363",
     "x86taka",
-    "Nishinoyama",
+    "nishinoyama",
     "Crow314",
     "logica0419",
     "mu-ruU1",
+    "tosuke",
   ]
 }

--- a/team-ictsc2022.tf
+++ b/team-ictsc2022.tf
@@ -8,7 +8,7 @@ locals {
     "K-shir0",
     "Explosive6363",
     "chaya2z",
-    "Nishinoyama",
+    "nishinoyama",
     "Crow314",
     "syuuya-nakatomi",
     "logica0419",

--- a/team-ictsc2023.tf
+++ b/team-ictsc2023.tf
@@ -2,7 +2,7 @@ locals {
   ictsc2023_members = [
     "onokatio",
     "x86taka",
-    "Nishinoyama",
+    "nishinoyama",
     "Crow314",
     "syuuya-nakatomi",
     "logica0419",

--- a/team-ictsc2024.tf
+++ b/team-ictsc2024.tf
@@ -2,7 +2,7 @@ locals {
   ictsc2024_members = [
     "onokatio",
     "x86taka",
-    "Nishinoyama",
+    "nishinoyama",
     "Crow314",
     "syuuya-nakatomi",
     "logica0419",


### PR DESCRIPTION
`actions/upload-artifact@v3` was deprecated on November 30, 2024.
We haven't  been able to use it since January 30th, 2025.

https://github.com/actions/upload-artifact
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/